### PR TITLE
FIX problem with 42header extention

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@
 #    Updated: 2024/11/09 13:32:18 by ailopez-         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
+
 NAME	= libft.a
 
 SRCS		=	ft_isalpha.c ft_isdigit.c ft_isalnum.c ft_isascii.c ft_isprint.c \


### PR DESCRIPTION
Add an empty line after the 42 header. The 42header extension for VS Code keeps the line right after the header (12) empty. The extension will touch this file even if you don't open it.